### PR TITLE
Add Improved Tablet & Mobile Breakpoints

### DIFF
--- a/about.html
+++ b/about.html
@@ -6,7 +6,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title>Lambda School - Web Dev Queue</title>
   <script src="https://kit.fontawesome.com/703be0d147.js"></script>
-  <link href="https://fonts.googleapis.com/css?family=Montserrat&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto&display=swap" rel="stylesheet">
   <link rel="stylesheet/less" type="text/css" href="less/about.less" />
   <script src="//cdnjs.cloudflare.com/ajax/libs/less.js/2.5.1/less.min.js"></script>
 </head>

--- a/css/about.css
+++ b/css/about.css
@@ -149,7 +149,7 @@ table {
   margin-left: 50%;
 }
 #home nav a {
-  font-family: 'Montserrat', sans-serif;
+  font-family: 'Roboto', sans-serif;
   color: white;
 }
 #home nav a:hover {
@@ -178,7 +178,7 @@ body .container,
 body .container2 {
   display: flex;
   padding: 0;
-  font-family: 'Montserrat', sans-serif;
+  font-family: 'Roboto', sans-serif;
   width: 75vw;
   position: relative;
   justify-content: space-evenly;
@@ -241,7 +241,7 @@ body .face2 .content {
   padding: 0;
 }
 body .face2 .content h3 {
-  font-family: 'Montserrat', sans-serif;
+  font-family: 'Roboto', sans-serif;
   color: white;
   text-align: center;
   margin-top: 10%;

--- a/css/about.css
+++ b/css/about.css
@@ -155,6 +155,21 @@ table {
 #home nav a:hover {
   color: #bb1333;
 }
+@media (max-width: 800px) {
+  #home nav {
+    width: 100%;
+    margin-left: 0%;
+  }
+}
+@media (max-width: 500px) {
+  #home nav {
+    width: 100%;
+    margin-left: 0%;
+  }
+  #home nav a {
+    font-size: 9px;
+  }
+}
 body {
   width: 75%;
   margin: 0 auto;
@@ -251,19 +266,20 @@ body .face2 .content a {
 @media (max-width: 800px) {
   .container {
     flex-direction: column;
+    align-items: center;
     margin-left: 2%;
   }
   .container2 {
     display: flex;
     flex-direction: column;
-    align-items: flex-end;
-    margin-top: -150%;
+    align-items: center;
+    margin-top: 2%;
     margin-right: 1%;
   }
 }
 @media (max-width: 500px) {
   .container {
-    margin-left: 20%;
+    margin-left: 1%;
   }
   .container2 {
     display: flex;

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>Lambda School - Web Dev Queue</title>
     <script src="https://kit.fontawesome.com/703be0d147.js"></script>
-    <link href="https://fonts.googleapis.com/css?family=Montserrat&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Roboto&display=swap" rel="stylesheet">
     <link rel="stylesheet/less" type="text/css" href="less/index.less" />
     <script src="//cdnjs.cloudflare.com/ajax/libs/less.js/2.5.1/less.min.js"></script>
   </head>

--- a/less/bodya.less
+++ b/less/bodya.less
@@ -23,6 +23,7 @@ body {
         overflow: hidden;
         transition: 0.5s;
         border-radius: 10px;
+
         .face1 {
           position: relative;
           display: flex;
@@ -92,20 +93,21 @@ body {
 @media @tablet {
   .container {
     flex-direction: column;
+    align-items: center;
     margin-left: 2%;
   }
   .container2 {
     display: flex;
     flex-direction: column;
-    align-items: flex-end;
-    margin-top: -150%;
+    align-items: center;
+    margin-top: 2%;
     margin-right: 1%;
   }
 }
 
 @media @mobile {
   .container {
-    margin-left: 20%;
+    margin-left: 1%;
   }
   .container2 {
     display: flex;

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -1,3 +1,4 @@
+// Parametric Mixins: fancy class we can use over and over agian. 
 .btn() {
     display: block;
     background: @colorB;
@@ -7,8 +8,6 @@
     text-align: center;
     font-size: 25px;
     border-radius: 5px;
-    border: 3px groove @colorF;
-    color: @colorC;
     font-family:@fontTitle;
     @media @mobile{
         font-size:15px;

--- a/less/navigation.less
+++ b/less/navigation.less
@@ -22,3 +22,20 @@
 	}
 }
 
+@media @tablet {
+	#home nav{
+		width: 100%;
+		margin-left: 0%;
+	}
+}
+
+@media @mobile {
+	#home nav{
+		width: 100%;
+		margin-left: 0%;
+
+		a{
+			font-size: 9px;
+		}
+	}
+}

--- a/less/variables.less
+++ b/less/variables.less
@@ -19,5 +19,5 @@
 @fontText: 'Poppins', sans-serif;
 
 // Media Queries
-@mobile: ~"(max-width: 500px)";
 @tablet: ~"(max-width: 800px)";
+@mobile: ~"(max-width: 500px)";

--- a/less/variables.less
+++ b/less/variables.less
@@ -15,7 +15,7 @@
 @border2: 1px solid green;
 
 //!Fonts
-@fontTitle: 'Montserrat', sans-serif;
+@fontTitle: 'Roboto', sans-serif;
 @fontText: 'Poppins', sans-serif;
 
 // Media Queries


### PR DESCRIPTION
Because:
- Media query design wasn't perfect

This commit:
- Updated the a links to show all in the nav bar for tablet and mobile design
- Updated the cards so that they all show in a column right below each other for table & mobile design in the body and navigation less files.